### PR TITLE
ROC-796-UnmarshalSpecialFloats

### DIFF
--- a/ros/dynamic_message.go
+++ b/ros/dynamic_message.go
@@ -483,7 +483,16 @@ func (m *DynamicMessage) UnmarshalJSON(buf []byte) error {
 					}
 					m.data[goField.Name] = data
 				} else {
-					m.data[goField.Name] = string(value)
+					//Case where we have marshalled a special float as a string
+					if string(value) == "nan" || string(value) == "+inf" || string(value) == "-inf" {
+						data, err = strconv.ParseFloat(string(value), 64)
+						if err != nil {
+							errors.Wrap(err, "Field: "+goField.Name)
+						}
+						m.data[goField.Name] = JsonFloat64{F: data.(float64)}
+					} else {
+						m.data[goField.Name] = string(value)
+					}
 				}
 			//We have a JSON number or int
 			case "number":

--- a/ros/json_float.go
+++ b/ros/json_float.go
@@ -36,9 +36,9 @@ func (f JsonFloat32) MarshalJSON() ([]byte, error) {
 	if math.IsNaN(float64(f.F)) {
 		return json.Marshal("nan")
 	} else if math.IsInf(float64(f.F), 1) {
-		return json.Marshal("inf+")
+		return json.Marshal("+inf")
 	} else if math.IsInf(float64(f.F), -1) {
-		return json.Marshal("inf-")
+		return json.Marshal("-inf")
 	}
 	return json.Marshal(f.F)
 }
@@ -51,9 +51,9 @@ func (f JsonFloat64) MarshalJSON() ([]byte, error) {
 	if math.IsNaN(f.F) {
 		return json.Marshal("nan")
 	} else if math.IsInf(f.F, 1) {
-		return json.Marshal("inf+")
+		return json.Marshal("+inf")
 	} else if math.IsInf(f.F, -1) {
-		return json.Marshal("inf-")
+		return json.Marshal("-inf")
 	}
 	return json.Marshal(f.F)
 }


### PR DESCRIPTION
As JsonFloat is marshalled as a json string for nan/inf values, we must specially parse it in unmarshal back into a JsonFloat
Also changed inf-/inf+ to -inf/+inf so that go can recognise these as floats when converting from string