### PR TITLE
ROC-882-Ros-log-configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e
 	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,13 @@
 github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e h1:oJCXMss/3rg5F6Poy9wG3JQusc58Mzk5B9Z6wSnssNE=
 github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e/go.mod h1:errmMKH8tTB49UR2A8C8DPYkyudelsYJwJFaZHQ6ik8=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/libtest/libtest_dynamic_message/rt-test.go
+++ b/libtest/libtest_dynamic_message/rt-test.go
@@ -2,13 +2,15 @@ package libtest_dynamic_message
 
 import (
 	"github.com/edwinhayes/rosgo/ros"
-	"time"
 	"os"
 	"testing"
+	"time"
 )
 
 var message string
+
 const targetMessage string = "hello world"
+
 var chanRx chan string
 
 // callback retrieves data from ros.DynamicMessage.data
@@ -27,7 +29,7 @@ func RTTest(t *testing.T) {
 		t.Error("error instantiating node; ", err)
 		return
 	}
-	node.Logger().SetSeverity(ros.LogLevelWarn)
+	node.SetLogLevel(1)
 	defer node.Shutdown()
 
 	// Make a dynamicMessageType.
@@ -51,12 +53,12 @@ func RTTest(t *testing.T) {
 
 	chanRx = make(chan string, 1)
 	chanNodeStop := make(chan struct{})
-	defer func() { chanNodeStop <- struct{}{} ; <-chanNodeStop }()
+	defer func() { chanNodeStop <- struct{}{}; <-chanNodeStop }()
 
 	go func() {
 		for node.OK() {
 			select {
-			case <- chanNodeStop:
+			case <-chanNodeStop:
 				chanNodeStop <- struct{}{}
 				return
 			default:
@@ -71,8 +73,8 @@ func RTTest(t *testing.T) {
 
 	// Look for the rx callback to report something.
 	select {
-	case rx := <- chanRx:
-		if (rx == targetMessage) {
+	case rx := <-chanRx:
+		if rx == targetMessage {
 			// Test passes.
 			return
 		}

--- a/libtest/libtest_publish_subscribe/rt-test.go
+++ b/libtest/libtest_publish_subscribe/rt-test.go
@@ -46,7 +46,7 @@ func RTTest(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	node.Logger().SetSeverity(ros.LogLevelInfo)
+	node.SetLogLevel(1)
 	defer node.Shutdown()
 
 	subscription = 1

--- a/libtest/libtest_service/rt-test.go
+++ b/libtest/libtest_service/rt-test.go
@@ -54,7 +54,7 @@ func RTTest(t *testing.T) {
 	quitThread := make(chan bool)
 	go spinServer(node2, quitThread)
 
-	node.Logger().SetSeverity(ros.LogLevelWarn)
+	node.SetLogLevel(1)
 	for node.OK() {
 		//Create  and call service request
 		service.Request.A = 10

--- a/ros/log.go
+++ b/ros/log.go
@@ -1,124 +1,21 @@
 package ros
 
 import (
-	"fmt"
-	"log"
-	"os"
+	"github.com/sirupsen/logrus"
 )
 
-//LogLevel is the global int to set the log level severity of a logger
-type LogLevel int
+// DefaultLogger represents a default logging instance
+var logger *logrus.Logger
 
-const (
-	//LogLevelDebug is zero value of LogLevel, most verbose
-	LogLevelDebug LogLevel = iota
-	//LogLevelInfo is default value of LogLevel
-	LogLevelInfo
-	//LogLevelWarn is a warning LogLevel
-	LogLevelWarn
-	//LogLevelError is a standard Error LogLevel
-	LogLevelError
-	//LogLevelFatal is a fatal Error LogLevel
-	LogLevelFatal
-)
-
-//Logger interface functions for log level severities
-type Logger interface {
-	Severity() LogLevel
-	SetSeverity(severity LogLevel)
-	Debug(v ...interface{})
-	Debugf(format string, v ...interface{})
-	Info(v ...interface{})
-	Infof(format string, v ...interface{})
-	Warn(v ...interface{})
-	Warnf(format string, v ...interface{})
-	Error(v ...interface{})
-	Errorf(format string, v ...interface{})
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-}
-
-type defaultLogger struct {
-	severity LogLevel
-}
-
-//NewDefaultLogger returns a new defaultLogger with severity LogLevelInfo
-func NewDefaultLogger() Logger {
-	logger := new(defaultLogger)
-	logger.severity = LogLevelInfo
-	return logger
-}
-
-func (logger *defaultLogger) Severity() LogLevel {
-	return logger.severity
-}
-
-func (logger *defaultLogger) SetSeverity(severity LogLevel) {
-	logger.severity = severity
-}
-
-func (logger *defaultLogger) Debug(v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelDebug) {
-		msg := fmt.Sprintf("[DEBUG] %s", fmt.Sprint(v...))
-		log.Println(msg)
+// DefaultLogger returns an instance of the default logger
+func DefaultLogger() *logrus.Logger {
+	if logger == nil {
+		logger = logrus.StandardLogger()
 	}
+	return logrus.StandardLogger()
 }
 
-func (logger *defaultLogger) Debugf(format string, v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelDebug) {
-		log.Printf("[DEBUG] "+format, v...)
-	}
-}
-
-func (logger *defaultLogger) Info(v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelInfo) {
-		msg := fmt.Sprintf("[INFO] %s", fmt.Sprint(v...))
-		log.Println(msg)
-	}
-}
-
-func (logger *defaultLogger) Infof(format string, v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelInfo) {
-		log.Printf("[INFO] "+format, v...)
-	}
-}
-
-func (logger *defaultLogger) Warn(v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelWarn) {
-		msg := fmt.Sprintf("[WARN] %s", fmt.Sprint(v...))
-		log.Println(msg)
-	}
-}
-
-func (logger *defaultLogger) Warnf(format string, v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelWarn) {
-		log.Printf("[WARN] "+format, v...)
-	}
-}
-
-func (logger *defaultLogger) Error(v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelError) {
-		msg := fmt.Sprintf("[ERROR] %s", fmt.Sprint(v...))
-		log.Println(msg)
-	}
-}
-
-func (logger *defaultLogger) Errorf(format string, v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelError) {
-		log.Printf("[ERROR]"+format, v...)
-	}
-}
-
-func (logger *defaultLogger) Fatal(v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelFatal) {
-		msg := fmt.Sprintf("[FATAL] %s", fmt.Sprint(v...))
-		log.Println(msg)
-	}
-}
-
-func (logger *defaultLogger) Fatalf(format string, v ...interface{}) {
-	if int(logger.severity) <= int(LogLevelFatal) {
-		log.Printf("[FATAL] "+format, v...)
-		os.Exit(1)
-	}
+// NewLogger returns a new instance of a logger
+func NewLogger() *logrus.Logger {
+	return logrus.New()
 }

--- a/ros/publisher.go
+++ b/ros/publisher.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net"
 	"sync"
 	"time"
@@ -167,7 +168,7 @@ type remoteSubscriberSession struct {
 	quitChan           chan struct{}
 	msgChan            chan []byte
 	errorChan          chan error
-	logger             Logger
+	logger             *logrus.Logger
 	connectCallback    func(SingleSubscriberPublisher)
 	disconnectCallback func(SingleSubscriberPublisher)
 }
@@ -280,7 +281,8 @@ func (session *remoteSubscriberSession) start() {
 	}
 	err = writeConnectionHeader(resHeaders, session.conn)
 	if err != nil {
-		panic(errors.New("failed to write response header"))
+		logger.Error("failed to write response header")
+		return
 	}
 
 	// 3. Start sending message
@@ -312,7 +314,7 @@ func (session *remoteSubscriberSession) start() {
 					continue
 				} else {
 					logger.Error(err)
-					panic(err)
+					return
 				}
 			}
 			logger.Debug(len(msg))
@@ -323,7 +325,7 @@ func (session *remoteSubscriberSession) start() {
 					continue
 				} else {
 					logger.Error(err)
-					panic(err)
+					return
 				}
 			}
 			logger.Debug(hex.EncodeToString(msg))

--- a/ros/ros.go
+++ b/ros/ros.go
@@ -1,6 +1,7 @@
 package ros
 
 import (
+	"github.com/sirupsen/logrus"
 	"time"
 )
 
@@ -43,7 +44,8 @@ type Node interface {
 	GetPublishedTopics(subgraph string) ([]interface{}, error)
 	GetTopicTypes() []interface{}
 
-	Logger() Logger
+	Logger() *logrus.Logger
+	SetLogLevel(loglevel uint32)
 
 	NonRosArgs() []string
 }

--- a/ros/service_client.go
+++ b/ros/service_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io"
 	"net"
 	"net/url"
@@ -12,14 +13,14 @@ import (
 )
 
 type defaultServiceClient struct {
-	logger    Logger
+	logger    *logrus.Logger
 	service   string
 	srvType   ServiceType
 	masterURI string
 	nodeID    string
 }
 
-func newDefaultServiceClient(logger Logger, nodeID string, masterURI string, service string, srvType ServiceType) *defaultServiceClient {
+func newDefaultServiceClient(logger *logrus.Logger, nodeID string, masterURI string, service string, srvType ServiceType) *defaultServiceClient {
 	client := new(defaultServiceClient)
 	client.logger = logger
 	client.service = service
@@ -83,7 +84,8 @@ func (c *defaultServiceClient) Call(srv Service) error {
 		logger.Debugf("  `%s` = `%s`", h.key, h.value)
 	}
 	if resHeaderMap["type"] != msgType || resHeaderMap["md5sum"] != md5sum {
-		logger.Fatalf("Incompatible message type!")
+		err = errors.New("incompatible message type")
+		return err
 	}
 	logger.Debug("Start receiving messages...")
 

--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io"
 	"net"
 	"reflect"
@@ -45,7 +46,7 @@ func newDefaultSubscriber(topic string, msgType MessageType, callback interface{
 	return sub
 }
 
-func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIURI string, masterURI string, jobChan chan func(), logger Logger) {
+func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIURI string, masterURI string, jobChan chan func(), logger *logrus.Logger) {
 	logger.Debugf("Subscriber goroutine for %s started.", sub.topic)
 	wg.Add(1)
 	defer wg.Done()
@@ -138,7 +139,7 @@ func (sub *defaultSubscriber) start(wg *sync.WaitGroup, nodeID string, nodeAPIUR
 	}
 }
 
-func startRemotePublisherConn(logger Logger,
+func startRemotePublisherConn(logger *logrus.Logger,
 	pubURI string, topic string, md5sum string,
 	msgType string, nodeID string,
 	msgChan chan messageEvent,


### PR DESCRIPTION
Replaces custom ROS logging with standard logrus
node.Logger().SetSeverity(ros.loglevel) now deprecated;
node.SetLogLevel(uint32) is replacement

Added specials flag "__ll" to node set log level on node initialization

Removed several panics and fatals