### PR TITLE
ROC-878-Subscriber-Memory-Leak

### DIFF
--- a/ros/subscriber.go
+++ b/ros/subscriber.go
@@ -239,7 +239,10 @@ func startRemotePublisherConn(logger *logrus.Entry,
 					}
 				}
 				event.ReceiptTime = time.Now()
-				msgChan <- messageEvent{bytes: buffer, event: event}
+				select {
+				case msgChan <- messageEvent{bytes: buffer, event: event}:
+				case <-time.After(time.Duration(5) * time.Second):
+				}
 				readingSize = true
 			}
 		}


### PR DESCRIPTION
Adds timeout to buffered msgChan write so that startRemotePublisherConn goroutines aren't left hanging